### PR TITLE
TT VALUE_NONE bugfix

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -76,12 +76,14 @@ void updatePv(Move* pv, Move move, const Move* currentPv) {
 }
 
 int valueToTT(int value, int ply) {
+    if (value == EVAL_NONE) return EVAL_NONE;
     if (value > EVAL_MATE_IN_MAX_PLY) value += ply;
     else if (value < -EVAL_MATE_IN_MAX_PLY) value -= ply;
     return value;
 }
 
 int valueFromTt(int value, int ply) {
+    if (value == EVAL_NONE) return EVAL_NONE;
     if (value > EVAL_MATE_IN_MAX_PLY) value -= ply;
     else if (value < -EVAL_MATE_IN_MAX_PLY) value += ply;
     return value;


### PR DESCRIPTION
Keep EVAL_NONE as it is when writing into / loading from tt.

https://openbench.yoshie2000.de/test/118/

Bench: 13679245