### PR TITLE
Don't reset history between searches

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -480,7 +480,6 @@ movesLoop:
 }
 
 void Thread::tsearch() {
-    initHistory();
     nodesSearched = 0;
 
     int maxDepth = searchParameters.depth == 0 ? MAX_PLY - 1 : searchParameters.depth;


### PR DESCRIPTION
https://openbench.yoshie2000.de/test/191/
The bounds of the test were accidentally set to gainer bounds, but the result passes non-regression:
ELO: 2.69 +- 4.65 [-1.96, 7.33]
LLR: 2.98 [-4.0, 1.0] (-2.94, 2.94)

Bench: 13768952